### PR TITLE
Minor changes for catering to str type and rsa default values during profile setup

### DIFF
--- a/nanopub/__main__.py
+++ b/nanopub/__main__.py
@@ -164,7 +164,7 @@ def setup(
         prompt = ('📬️ Would you like to publish your profile to the nanopub servers? '
                   'This links your ORCID iD to your RSA key, thereby making all your '
                   'publications linkable to you')
-        publish_resp = typer.prompt(prompt, type=Path, default="")
+        publish_resp = typer.prompt(prompt, type=str, default="")
         if publish_resp and publish_resp.lower().startswith("y"):
             publish = True
         else:
@@ -172,13 +172,15 @@ def setup(
 
     if not keypair and not newkeys:
         prompt = '🔓️ Provide the path to your public RSA key: ' \
-                 f'Leave empty for using the one in {USER_CONFIG_DIR}'
-        public_key = typer.prompt(prompt, type=Path, default="")
+                'Leave empty for using the one in: '
+        public_key = typer.prompt(prompt, type=Path,
+                                  default=DEFAULT_PUBLIC_KEY_PATH)
         if not public_key:
             keypair = None
         else:
             prompt = '🔑 Provide the path to your private RSA key: '
-            private_key = typer.prompt(prompt, type=Path)
+            private_key = typer.prompt(prompt, type=Path,
+                                       default=DEFAULT_PRIVATE_KEY_PATH)
             keypair = public_key, private_key
 
     if not keypair:
@@ -195,8 +197,10 @@ def setup(
         public_key_path, private_key = keypair
 
         # Copy the keypair to the default location
-        shutil.copy(public_key_path, USER_CONFIG_DIR / PUBLIC_KEY_FILE)
-        shutil.copy(private_key, USER_CONFIG_DIR / PRIVATE_KEY_FILE)
+        if not os.path.exists(DEFAULT_PUBLIC_KEY_PATH):
+            shutil.copy(public_key_path, USER_CONFIG_DIR / PUBLIC_KEY_FILE)
+        if not os.path.exists(DEFAULT_PRIVATE_KEY_PATH):
+            shutil.copy(private_key, USER_CONFIG_DIR / PRIVATE_KEY_FILE)
 
         print(f'🚚 Your RSA keys have been copied to {USER_CONFIG_DIR}')
 

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -113,10 +113,10 @@ class Profile:
         profile_path = os.path.join(folder, "profile.yml")
 
         # Store keys
-        if not private_key_path.exists():
+        if not os.path.exists(private_key_path):
             with open(private_key_path, "w") as f:
                 f.write(self.private_key + '\n')
-        if not public_key_path.exists():
+        if not os.path.exists(public_key_path):
             with open(public_key_path, "w") as f:
                 f.write(self.public_key)
 


### PR DESCRIPTION
This request caters to the following errors -

1. For the setup question, "Would you like to publish...", the type was set to path, modified that to str. 
2. For the RSA keys, the default values were not taken into account, so set the default values.
3. Added conditionality for validating previous existing nanopub rsa path. Maybe removed if unnecessary.